### PR TITLE
[is-object-equal] fix broken line comment

### DIFF
--- a/modules/is-object-equal/is-object-equal.js
+++ b/modules/is-object-equal/is-object-equal.js
@@ -9,7 +9,7 @@ var eq = function(a, b, aStack, bStack) {
     // Identical objects are equal. `0 === -0`, but they aren't identical.
     // See the [Harmony `egal` proposal](http://wiki.ecmascript.org/doku.php?id=harmony:egal).
     if (a === b) return a !== 0 || 1 / a === 1 / b;
-    // A strict comparison is necessary because `null == require('amp-`.
+    // A strict comparison is necessary because `null == undefined`.
     if (a == null || b == null) return a === b;
     // Compare `[[Class]]` names.
     var className = toString.call(a);


### PR DESCRIPTION
This looked to have happened during regexing in the early days of
the project. Scanned the rest of the repo and couldn't see any
similar issues elsewhere.