### PR TITLE
Add times.

### DIFF
--- a/bin/test-all.js
+++ b/bin/test-all.js
@@ -66,6 +66,7 @@ require('../modules/is-undefined/test');
 require('../modules/iteratee/test');
 require('../modules/random/test');
 require('../modules/result/test');
+require('../modules/times/test');
 require('../modules/unique-id/test');
 require('../modules/create-callback/test');
 require('../modules/internal-flatten/test');

--- a/bin/test-server.js
+++ b/bin/test-server.js
@@ -62,6 +62,7 @@ require('../modules/is-undefined/test');
 require('../modules/iteratee/test');
 require('../modules/random/test');
 require('../modules/result/test');
+require('../modules/times/test');
 require('../modules/unique-id/test');
 require('../modules/create-callback/test');
 require('../modules/internal-flatten/test');

--- a/index.html
+++ b/index.html
@@ -22,11 +22,11 @@
   <body class="docs-page">
     <nav class="nav-main cf"><a href="/" class="logo logo-ampersand">Amp</a></nav>
     <div class="docs cf">
-      <nav class="nav-docs"><a href="/" class="logo logo-ampersand"></a><a href="#intro" class="section-top">Introduction</a><a href="http://ampersandjs.com" class="section-top external">Ampersand.js</a><a href="https://github.com/ampersandjs/amp" class="section-top external">GitHub Project</a><a href="https://github.com/ampersandjs/amp/issues" class="section-top external">Bugs</a><a href="#sizes" class="section-top external">Filesizes</a><a href="#" class="section-top">dom</a><a href="#amp-add-class" class="section-sub">amp-add-class</a><a href="#amp-has-class" class="section-sub">amp-has-class</a><a href="#amp-remove-class" class="section-sub">amp-remove-class</a><a href="#amp-toggle-class" class="section-sub">amp-toggle-class</a><a href="#" class="section-top">functions</a><a href="#amp-bind" class="section-sub">amp-bind</a><a href="#amp-debounce" class="section-sub">amp-debounce</a><a href="#amp-delay" class="section-sub">amp-delay</a><a href="#amp-limit-calls" class="section-sub">amp-limit-calls</a><a href="#amp-negate" class="section-sub">amp-negate</a><a href="#amp-once" class="section-sub">amp-once</a><a href="#" class="section-top">collections</a><a href="#amp-contains" class="section-sub">amp-contains</a><a href="#amp-each" class="section-sub">amp-each</a><a href="#amp-every" class="section-sub">amp-every</a><a href="#amp-filter" class="section-sub">amp-filter</a><a href="#amp-find" class="section-sub">amp-find</a><a href="#amp-invoke" class="section-sub">amp-invoke</a><a href="#amp-map" class="section-sub">amp-map</a><a href="#amp-pluck" class="section-sub">amp-pluck</a><a href="#amp-reduce" class="section-sub">amp-reduce</a><a href="#amp-reject" class="section-sub">amp-reject</a><a href="#amp-sample" class="section-sub">amp-sample</a><a href="#amp-shuffle" class="section-sub">amp-shuffle</a><a href="#amp-size" class="section-sub">amp-size</a><a href="#amp-some" class="section-sub">amp-some</a><a href="#amp-to-array" class="section-sub">amp-to-array</a><a href="#" class="section-top">arrays</a><a href="#amp-difference" class="section-sub">amp-difference</a><a href="#amp-first" class="section-sub">amp-first</a><a href="#amp-flatten" class="section-sub">amp-flatten</a><a href="#amp-index-of" class="section-sub">amp-index-of</a><a href="#amp-jump" class="section-sub">amp-jump</a><a href="#amp-last" class="section-sub">amp-last</a><a href="#amp-range" class="section-sub">amp-range</a><a href="#amp-unique" class="section-sub">amp-unique</a><a href="#" class="section-top">objects</a><a href="#amp-clone" class="section-sub">amp-clone</a><a href="#amp-defaults" class="section-sub">amp-defaults</a><a href="#amp-extend" class="section-sub">amp-extend</a><a href="#amp-has" class="section-sub">amp-has</a><a href="#amp-invert" class="section-sub">amp-invert</a><a href="#amp-keys" class="section-sub">amp-keys</a><a href="#amp-matches" class="section-sub">amp-matches</a><a href="#amp-merge" class="section-sub">amp-merge</a><a href="#amp-omit" class="section-sub">amp-omit</a><a href="#amp-pairs" class="section-sub">amp-pairs</a><a href="#amp-pick" class="section-sub">amp-pick</a><a href="#amp-property" class="section-sub">amp-property</a><a href="#amp-values" class="section-sub">amp-values</a><a href="#" class="section-top">strings</a><a href="#amp-escape" class="section-sub">amp-escape</a><a href="#amp-includes" class="section-sub">amp-includes</a><a href="#amp-to-camel-case" class="section-sub">amp-to-camel-case</a><a href="#amp-trim" class="section-sub">amp-trim</a><a href="#" class="section-top">utils</a><a href="#amp-is-arguments" class="section-sub">amp-is-arguments</a><a href="#amp-is-array" class="section-sub">amp-is-array</a><a href="#amp-is-boolean" class="section-sub">amp-is-boolean</a><a href="#amp-is-date" class="section-sub">amp-is-date</a><a href="#amp-is-empty" class="section-sub">amp-is-empty</a><a href="#amp-is-function" class="section-sub">amp-is-function</a><a href="#amp-is-nan" class="section-sub">amp-is-nan</a><a href="#amp-is-null" class="section-sub">amp-is-null</a><a href="#amp-is-number" class="section-sub">amp-is-number</a><a href="#amp-is-object" class="section-sub">amp-is-object</a><a href="#amp-is-object-equal" class="section-sub">amp-is-object-equal</a><a href="#amp-is-regexp" class="section-sub">amp-is-regexp</a><a href="#amp-is-string" class="section-sub">amp-is-string</a><a href="#amp-is-undefined" class="section-sub">amp-is-undefined</a><a href="#amp-iteratee" class="section-sub">amp-iteratee</a><a href="#amp-random" class="section-sub">amp-random</a><a href="#amp-result" class="section-sub">amp-result</a><a href="#amp-unique-id" class="section-sub">amp-unique-id</a><a href="#" class="section-top">internal</a><a href="#amp-create-callback" class="section-sub">amp-create-callback</a><a href="#amp-internal-flatten" class="section-sub">amp-internal-flatten</a>
+      <nav class="nav-docs"><a href="/" class="logo logo-ampersand"></a><a href="#intro" class="section-top">Introduction</a><a href="http://ampersandjs.com" class="section-top external">Ampersand.js</a><a href="https://github.com/ampersandjs/amp" class="section-top external">GitHub Project</a><a href="https://github.com/ampersandjs/amp/issues" class="section-top external">Bugs</a><a href="#sizes" class="section-top external">Filesizes</a><a href="#" class="section-top">dom</a><a href="#amp-add-class" class="section-sub">amp-add-class</a><a href="#amp-has-class" class="section-sub">amp-has-class</a><a href="#amp-remove-class" class="section-sub">amp-remove-class</a><a href="#amp-toggle-class" class="section-sub">amp-toggle-class</a><a href="#" class="section-top">functions</a><a href="#amp-bind" class="section-sub">amp-bind</a><a href="#amp-debounce" class="section-sub">amp-debounce</a><a href="#amp-delay" class="section-sub">amp-delay</a><a href="#amp-limit-calls" class="section-sub">amp-limit-calls</a><a href="#amp-negate" class="section-sub">amp-negate</a><a href="#amp-once" class="section-sub">amp-once</a><a href="#" class="section-top">collections</a><a href="#amp-contains" class="section-sub">amp-contains</a><a href="#amp-each" class="section-sub">amp-each</a><a href="#amp-every" class="section-sub">amp-every</a><a href="#amp-filter" class="section-sub">amp-filter</a><a href="#amp-find" class="section-sub">amp-find</a><a href="#amp-invoke" class="section-sub">amp-invoke</a><a href="#amp-map" class="section-sub">amp-map</a><a href="#amp-pluck" class="section-sub">amp-pluck</a><a href="#amp-reduce" class="section-sub">amp-reduce</a><a href="#amp-reject" class="section-sub">amp-reject</a><a href="#amp-sample" class="section-sub">amp-sample</a><a href="#amp-shuffle" class="section-sub">amp-shuffle</a><a href="#amp-size" class="section-sub">amp-size</a><a href="#amp-some" class="section-sub">amp-some</a><a href="#amp-to-array" class="section-sub">amp-to-array</a><a href="#" class="section-top">arrays</a><a href="#amp-difference" class="section-sub">amp-difference</a><a href="#amp-first" class="section-sub">amp-first</a><a href="#amp-flatten" class="section-sub">amp-flatten</a><a href="#amp-index-of" class="section-sub">amp-index-of</a><a href="#amp-jump" class="section-sub">amp-jump</a><a href="#amp-last" class="section-sub">amp-last</a><a href="#amp-range" class="section-sub">amp-range</a><a href="#amp-unique" class="section-sub">amp-unique</a><a href="#" class="section-top">objects</a><a href="#amp-clone" class="section-sub">amp-clone</a><a href="#amp-defaults" class="section-sub">amp-defaults</a><a href="#amp-extend" class="section-sub">amp-extend</a><a href="#amp-has" class="section-sub">amp-has</a><a href="#amp-invert" class="section-sub">amp-invert</a><a href="#amp-keys" class="section-sub">amp-keys</a><a href="#amp-matches" class="section-sub">amp-matches</a><a href="#amp-merge" class="section-sub">amp-merge</a><a href="#amp-omit" class="section-sub">amp-omit</a><a href="#amp-pairs" class="section-sub">amp-pairs</a><a href="#amp-pick" class="section-sub">amp-pick</a><a href="#amp-property" class="section-sub">amp-property</a><a href="#amp-values" class="section-sub">amp-values</a><a href="#" class="section-top">strings</a><a href="#amp-escape" class="section-sub">amp-escape</a><a href="#amp-includes" class="section-sub">amp-includes</a><a href="#amp-to-camel-case" class="section-sub">amp-to-camel-case</a><a href="#amp-trim" class="section-sub">amp-trim</a><a href="#" class="section-top">utils</a><a href="#amp-is-arguments" class="section-sub">amp-is-arguments</a><a href="#amp-is-array" class="section-sub">amp-is-array</a><a href="#amp-is-boolean" class="section-sub">amp-is-boolean</a><a href="#amp-is-date" class="section-sub">amp-is-date</a><a href="#amp-is-empty" class="section-sub">amp-is-empty</a><a href="#amp-is-function" class="section-sub">amp-is-function</a><a href="#amp-is-nan" class="section-sub">amp-is-nan</a><a href="#amp-is-null" class="section-sub">amp-is-null</a><a href="#amp-is-number" class="section-sub">amp-is-number</a><a href="#amp-is-object" class="section-sub">amp-is-object</a><a href="#amp-is-object-equal" class="section-sub">amp-is-object-equal</a><a href="#amp-is-regexp" class="section-sub">amp-is-regexp</a><a href="#amp-is-string" class="section-sub">amp-is-string</a><a href="#amp-is-undefined" class="section-sub">amp-is-undefined</a><a href="#amp-iteratee" class="section-sub">amp-iteratee</a><a href="#amp-random" class="section-sub">amp-random</a><a href="#amp-result" class="section-sub">amp-result</a><a href="#amp-times" class="section-sub">amp-times</a><a href="#amp-unique-id" class="section-sub">amp-unique-id</a><a href="#" class="section-top">internal</a><a href="#amp-create-callback" class="section-sub">amp-create-callback</a><a href="#amp-internal-flatten" class="section-sub">amp-internal-flatten</a>
       </nav>
       <div class="docs-content">
         <section><a name="intro" href="#intro" class="anchor">
-            <h1><span class="header-link"></span>Amp &mdash; 70 utility functions as individual npm modules</h1></a>
+            <h1><span class="header-link"></span>Amp &mdash; 71 utility functions as individual npm modules</h1></a>
           <div class="illustration amp"><img src="/documentation/public/images/ampersand-amp.svg"></div>
           <p>This page is the consolidated reference for all the amp modules in a single page for the sake of being 'cmd+f' friendly.</p>
           <p>All modules are unit tested in a wide range of browsers (including IE6+) with a CI system composed of <a href="https://saucelabs.com">SauceLabs</a> and <a href="https://travis-ci.org/AmpersandJS/amp">Travis CI</a> by using <a href="https://www.npmjs.org/package/zuul">zuul</a> and <a href="https://www.npmjs.org/package/tape">tape</a>.</p>
@@ -7781,6 +7781,95 @@ test('amp-result', function(t) {
             <div class="dependency-list">
               <ul>
                 <li><a href="#amp-is-function">amp-is-function</a></li>
+              </ul>
+            </div>
+          </div>
+          <div></div>
+        </section>
+        <section class="module"><a name="amp-times" href="#amp-times" class="anchor">
+            <h1><span class="header-link"></span>amp-times</h1></a>
+          <div class="module-card">
+            <h4 class="module-name">amp-times</h4>
+            <p class="module-version">v1.0.0</p>
+            <p class="module-links"><a href="https://www.npmjs.org/package/amp-times">npm</a><a href="https://github.com/ampersandjs/amp/tree/master/modules/times">github</a></p>
+          </div>
+          <div>
+            <h3>Docs</h3>
+            <div><p>Runs a function <code>n</code> times.</p>
+</div>
+            <h3>Example Usage</h3>
+            <pre><code class="lang-javascript hljs">var times = require('amp-times');
+
+var timesCalled = 0;
+var logCalls = function () {
+    console.log(timesCalled);
+    return ++timesCalled;
+};
+
+times(2, logCalls);
+//=&gt; 0
+//=&gt; 1
+</code></pre>
+            <div class="code">
+              <button class="toggle">Show the code</button>
+              <pre style="display: none"><code class="lang-javascript hljs">var createCallback = require('amp-create-callback');
+
+module.exports = function times(n, iteratee, context) {
+    var accum = Array(Math.max(0, n));
+    iteratee = createCallback(iteratee, context, 1);
+    for (var i = 0; i &lt; n; i++) accum[i] = iteratee(i);
+    return accum;
+};
+</code></pre>
+            </div>
+            <div class="tests">
+              <button class="toggle">Show the tests</button>
+              <pre style="display: none"><code class="lang-javascript hljs">var test = require('tape');
+var times = require('./times');
+
+test('amp-times', function (t) {
+
+    function identity(x) {
+        return x;
+    }
+
+    // is 0 indexed
+    var vals = [];
+    times(3, function (i) { vals.push(i); });
+    t.deepEqual(vals, [0, 1, 2], 'is 0 indexed');
+
+    // collects return values
+    t.deepEqual([0, 1, 2], times(3, function(i) { return i; }), 'collects return values');
+
+    // optionally applies context to iterested function
+    var context = {count: 0};
+    times(3, function(){
+        this.count++;
+    }, context);
+    t.equal(context.count, 3, 'optionally applies context to the iterated function');
+
+    // doesn't barf on weird values
+    t.deepEqual(times(0, identity), [], 'doesn\'t barf on 0');
+    t.deepEqual(times(-1, identity), [], 'doesn\'t barf on -1');
+    t.deepEqual(times(parseFloat('-Infinity'), identity), [], 'doesn\'t barf on -Infinity');
+
+    t.end();
+
+});
+</code></pre>
+            </div>
+            <h3>Estimated bundle size increase</h3>
+            <p>~178 B (<a href="#sizes">details</a>)</p>
+            <h4>Dependencies</h4>
+            <div style="display: none">
+              <ul>
+                <li><a href="#amp-create-callback">amp-create-callback</a>
+                </li>
+              </ul>
+            </div>
+            <div class="dependency-list">
+              <ul>
+                <li><a href="#amp-create-callback">amp-create-callback</a></li>
               </ul>
             </div>
           </div>

--- a/index.html
+++ b/index.html
@@ -4532,7 +4532,7 @@ test('amp-clone', function (t) {
 </code></pre>
             </div>
             <h3>Estimated bundle size increase</h3>
-            <p>~219 B (<a href="#sizes">details</a>)</p>
+            <p>~220 B (<a href="#sizes">details</a>)</p>
             <h4>Dependencies</h4>
             <div style="display: none">
               <ul>
@@ -5276,7 +5276,7 @@ test('amp-merge', function (t) {
 });</code></pre>
             </div>
             <h3>Estimated bundle size increase</h3>
-            <p>~165 B (<a href="#sizes">details</a>)</p>
+            <p>~166 B (<a href="#sizes">details</a>)</p>
             <h4>Dependencies</h4>
             <div style="display: none">
               <ul>

--- a/modules.json
+++ b/modules.json
@@ -281,6 +281,10 @@
       "license": "underscore"
     },
     {
+      "name": "times",
+      "license": "underscore"
+    },
+    {
       "name": "unique-id",
       "license": "underscore"
     }

--- a/modules/clone/package.json
+++ b/modules/clone/package.json
@@ -7,7 +7,7 @@
     "internal": false,
     "size": {
       "original": "1.1 kB",
-      "minified": "219 B"
+      "minified": "220 B"
     }
   },
   "bugs": "https://github.com/ampersandjs/amp/issues",

--- a/modules/merge/package.json
+++ b/modules/merge/package.json
@@ -7,7 +7,7 @@
     "internal": false,
     "size": {
       "original": "757 B",
-      "minified": "165 B"
+      "minified": "166 B"
     }
   },
   "bugs": "https://github.com/ampersandjs/amp/issues",

--- a/modules/times/LICENSE.md
+++ b/modules/times/LICENSE.md
@@ -1,0 +1,20 @@
+Copyright © 2015 &yet, LLC and AmpersandJS contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/modules/times/NOTICE
+++ b/modules/times/NOTICE
@@ -1,0 +1,28 @@
+This amp module uses code from Underscore. 
+The license below is included for compliance and with gratitude 
+toward Jeremy Ashkenas and the other authors for their generous licensing!
+____________________
+
+Copyright (c) 2009-2014 Jeremy Ashkenas, DocumentCloud and Investigative
+Reporters & Editors
+
+Permission is hereby granted, free of charge, to any person
+obtaining a copy of this software and associated documentation
+files (the "Software"), to deal in the Software without
+restriction, including without limitation the rights to use,
+copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.

--- a/modules/times/README.md
+++ b/modules/times/README.md
@@ -1,0 +1,5 @@
+# amp-times
+
+See [the documentation](http://amp.ampersandjs.com#amp-times) for more info.
+
+Part of the [amp project](http://amp.ampersandjs.com#amp-times), initially created by [@HenrikJoreteg](http://twitter.com/henrikjoreteg).

--- a/modules/times/doc.md
+++ b/modules/times/doc.md
@@ -1,0 +1,1 @@
+Runs a function `n` times.

--- a/modules/times/example.js
+++ b/modules/times/example.js
@@ -1,0 +1,11 @@
+var times = require('amp-times');
+
+var timesCalled = 0;
+var logCalls = function () {
+    console.log(timesCalled);
+    return ++timesCalled;
+};
+
+times(2, logCalls);
+//=> 0
+//=> 1

--- a/modules/times/package.json
+++ b/modules/times/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "amp-times",
+  "description": "times function part of http://amp.ampersandjs.com.",
+  "version": "1.0.0",
+  "author": "Darcy Murphy <darcy.murphy@loudbit.com>",
+  "amp": {
+    "size": {
+      "original": "1.09 kB",
+      "minified": "178 B"
+    },
+    "internal": false
+  },
+  "bugs": "https://github.com/ampersandjs/amp/issues",
+  "dependencies": {
+    "amp-create-callback": "^1.0.0"
+  },
+  "devDependencies": {
+    "tape": "^3.0.3"
+  },
+  "homepage": "http://amp.ampersandjs.com/#amp-times",
+  "keywords": [
+    "amp",
+    "util",
+    "utils"
+  ],
+  "license": "MIT",
+  "main": "times.js",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/ampersandjs/amp"
+  },
+  "scripts": {
+    "test": "node test.js"
+  }
+}

--- a/modules/times/sig.js
+++ b/modules/times/sig.js
@@ -1,0 +1,1 @@
+times(number, function, *context);

--- a/modules/times/test.js
+++ b/modules/times/test.js
@@ -1,0 +1,32 @@
+var test = require('tape');
+var times = require('./times');
+
+test('amp-times', function (t) {
+
+    function identity(x) {
+        return x;
+    }
+
+    // is 0 indexed
+    var vals = [];
+    times(3, function (i) { vals.push(i); });
+    t.deepEqual(vals, [0, 1, 2], 'is 0 indexed');
+
+    // collects return values
+    t.deepEqual([0, 1, 2], times(3, function(i) { return i; }), 'collects return values');
+
+    // optionally applies context to iterated function
+    var context = {count: 0};
+    times(3, function(){
+        this.count++;
+    }, context);
+    t.equal(context.count, 3, 'optionally applies context to the iterated function');
+
+    // doesn't barf on weird values
+    t.deepEqual(times(0, identity), [], 'doesn\'t barf on 0');
+    t.deepEqual(times(-1, identity), [], 'doesn\'t barf on -1');
+    t.deepEqual(times(parseFloat('-Infinity'), identity), [], 'doesn\'t barf on -Infinity');
+
+    t.end();
+
+});

--- a/modules/times/times.js
+++ b/modules/times/times.js
@@ -1,0 +1,8 @@
+var createCallback = require('amp-create-callback');
+
+module.exports = function times(n, iteratee, context) {
+    var accum = Array(Math.max(0, n));
+    iteratee = createCallback(iteratee, context, 1);
+    for (var i = 0; i < n; i++) accum[i] = iteratee(i);
+    return accum;
+};


### PR DESCRIPTION
Ports the underscore method to amp.

Also, the sizes for clone and merge were calculated a little differently than before after running `npm run build`. I'm not sure why, so I included those in a separate commit.