### PR TITLE
Fixing to initial copyright year

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,4 +1,4 @@
-Copyright © 2015 &yet, LLC and AmpersandJS contributors
+Copyright © 2014 &yet, LLC and AmpersandJS contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the


### PR DESCRIPTION
According to http://www.copyright.gov/circs/circ01.pdf (See screenshot of relevant section below) , listing the first year of publication in the copyright is enough

![selection_008](https://cloud.githubusercontent.com/assets/829526/12409934/7021c3a6-be95-11e5-8d1a-18f6948571e0.png)

The commit b6c1d219abff2f5c2b changed this to 2015. This commit will revert it back to 2014 (As it was in the initial commit - 06fd4a28da58f198ef1e6f37b0b707 )